### PR TITLE
Fix toLower for HTTPParameterObfusactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/robtimus/go-obfuscate
 
-go 1.22.0
+go 1.24

--- a/httpParameters.go
+++ b/httpParameters.go
@@ -10,11 +10,10 @@ import (
 // HTTPParameterObfuscator represents an object that can obfuscate HTTP query and form parameter strings,
 // as well as separate parameter values.
 type HTTPParameterObfuscator struct {
-	obfuscators            map[string]Obfuscator
-	onError                ErrorStrategy
-	printf                 func(format string, v ...any)
-	panicf                 func(format string, v ...any)
-	normilizeParameterName func(name string) string
+	obfuscators map[string]Obfuscator
+	onError     ErrorStrategy
+	printf      func(format string, v ...any)
+	panicf      func(format string, v ...any)
 }
 
 // HTTPParameterObfuscatorOptions represents the configurable options used by HTTPParameterObfuscator instances.
@@ -23,38 +22,30 @@ type HTTPParameterObfuscatorOptions struct {
 	OnError ErrorStrategy
 	// Logger represents the optional logger to use in case OnError is OnErrorLog or OnErrorPanic.
 	Logger *log.Logger
-	// NormilizeParamterName represents the optional func for normilizing paramter names.
-	NormilizeParamterName func(name string) string
 }
 
 // HTTPParameters creates a new HTTP parameter obfuscator.
 func HTTPParameters(obfuscators map[string]Obfuscator, options *HTTPParameterObfuscatorOptions) HTTPParameterObfuscator {
-	var o = HTTPParameterObfuscator{
-		printf:                 defaultPrintf,
-		panicf:                 defaultPanicf,
-		normilizeParameterName: strings.ToLower,
-		obfuscators:            make(map[string]Obfuscator),
-	}
-
-	if options != nil {
-		o.onError = options.OnError
-		if options.Logger != nil {
-			o.printf = options.Logger.Printf
-			o.panicf = options.Logger.Panicf
-		}
-	}
-
+	obfuscatorMap := map[string]Obfuscator{}
 	for headerName, obfuscator := range obfuscators {
-		o.obfuscators[o.normilizeParameterName(headerName)] = obfuscator
+		obfuscatorMap[strings.ToLower(headerName)] = obfuscator
 	}
 
-	return o
+	var onError ErrorStrategy
+	printf := defaultPrintf
+	panicf := defaultPanicf
+	if options != nil {
+		onError = options.OnError
+		printf = options.Logger.Printf
+		panicf = options.Logger.Panicf
+	}
+
+	return HTTPParameterObfuscator{obfuscators: obfuscatorMap, onError: onError, printf: printf, panicf: panicf}
 }
 
 // ObfuscateParameter obfuscates the given value for a parameter with the given name.
 func (o HTTPParameterObfuscator) ObfuscateParameter(name, value string) string {
-	name = o.normilizeParameterName(name)
-	if obfuscator, ok := o.obfuscators[name]; ok {
+	if obfuscator, ok := o.obfuscators[strings.ToLower(name)]; ok {
 		return obfuscator.ObfuscateString(value)
 	}
 	return value

--- a/httpParameters.go
+++ b/httpParameters.go
@@ -10,10 +10,11 @@ import (
 // HTTPParameterObfuscator represents an object that can obfuscate HTTP query and form parameter strings,
 // as well as separate parameter values.
 type HTTPParameterObfuscator struct {
-	obfuscators map[string]Obfuscator
-	onError     ErrorStrategy
-	printf      func(format string, v ...any)
-	panicf      func(format string, v ...any)
+	obfuscators            map[string]Obfuscator
+	onError                ErrorStrategy
+	printf                 func(format string, v ...any)
+	panicf                 func(format string, v ...any)
+	normilizeParameterName func(name string) string
 }
 
 // HTTPParameterObfuscatorOptions represents the configurable options used by HTTPParameterObfuscator instances.
@@ -22,29 +23,37 @@ type HTTPParameterObfuscatorOptions struct {
 	OnError ErrorStrategy
 	// Logger represents the optional logger to use in case OnError is OnErrorLog or OnErrorPanic.
 	Logger *log.Logger
+	// NormilizeParamterName represents the optional func for normilizing paramter names.
+	NormilizeParamterName func(name string) string
 }
 
 // HTTPParameters creates a new HTTP parameter obfuscator.
 func HTTPParameters(obfuscators map[string]Obfuscator, options *HTTPParameterObfuscatorOptions) HTTPParameterObfuscator {
-	obfuscatorMap := map[string]Obfuscator{}
-	for headerName, obfuscator := range obfuscators {
-		obfuscatorMap[strings.ToLower(headerName)] = obfuscator
+	var o = HTTPParameterObfuscator{
+		printf:                 defaultPrintf,
+		panicf:                 defaultPanicf,
+		normilizeParameterName: strings.ToLower,
+		obfuscators:            make(map[string]Obfuscator),
 	}
 
-	var onError ErrorStrategy
-	printf := defaultPrintf
-	panicf := defaultPanicf
 	if options != nil {
-		onError = options.OnError
-		printf = options.Logger.Printf
-		panicf = options.Logger.Panicf
+		o.onError = options.OnError
+		if options.Logger != nil {
+			o.printf = options.Logger.Printf
+			o.panicf = options.Logger.Panicf
+		}
 	}
 
-	return HTTPParameterObfuscator{obfuscators: obfuscatorMap, onError: onError, printf: printf, panicf: panicf}
+	for headerName, obfuscator := range obfuscators {
+		o.obfuscators[o.normilizeParameterName(headerName)] = obfuscator
+	}
+
+	return o
 }
 
 // ObfuscateParameter obfuscates the given value for a parameter with the given name.
 func (o HTTPParameterObfuscator) ObfuscateParameter(name, value string) string {
+	name = o.normilizeParameterName(name)
 	if obfuscator, ok := o.obfuscators[name]; ok {
 		return obfuscator.ObfuscateString(value)
 	}

--- a/httpParameters_test.go
+++ b/httpParameters_test.go
@@ -46,9 +46,7 @@ func TestObfuscateParameterString(t *testing.T) {
 }
 
 func TestObfuscateParameterStringWithNormilize(t *testing.T) {
-	obfuscator := newHTTPParameterObfuscator(&HTTPParameterObfuscatorOptions{
-		NormilizeParamterName: strings.ToUpper,
-	})
+	obfuscator := newHTTPParameterObfuscator(nil)
 
 	input := "FOO=bar&hello=world&EMptY=&no-value"
 

--- a/httpParameters_test.go
+++ b/httpParameters_test.go
@@ -45,6 +45,28 @@ func TestObfuscateParameterString(t *testing.T) {
 	}
 }
 
+func TestObfuscateParameterStringWithNormilize(t *testing.T) {
+	obfuscator := newHTTPParameterObfuscator(&HTTPParameterObfuscatorOptions{
+		NormilizeParamterName: strings.ToUpper,
+	})
+
+	input := "FOO=bar&hello=world&EMptY=&no-value"
+
+	actual := obfuscator.ObfuscateString(input)
+
+	expected := "FOO=***&hello=world&EMptY=&no-value"
+
+	assertEqual(t, expected, actual)
+
+	actual, err := obfuscator.ObfuscateParameterString(input)
+
+	assertEqual(t, expected, actual)
+
+	if err != nil {
+		t.Errorf("unexpected error: '%v'", err)
+	}
+}
+
 func TestObfuscateParameterStringWithError(t *testing.T) {
 	output := &strings.Builder{}
 	logger := log.New(output, "", 0)


### PR DESCRIPTION
HI @robtimus!

I was reserching to quickly solve my data obfuscation task. 
I came across your repository and found it interesting. However, I encountered a problem: when using `HTTPParameterObfuscator`, it applies `strings.ToLower` to the input map https://github.com/robtimus/go-obfuscate/blob/master/httpParameters.go#L31. 
But later, when searching for keys to obfuscate value, it does not apply `strings.ToLower` https://github.com/robtimus/go-obfuscate/blob/master/httpParameters.go#L48. 
I looked into how this is implemented in your `HTTPHeaderObfuscator`, and there it is consistently done with ToLower: this https://github.com/robtimus/go-obfuscate/blob/master/httpHeaders.go#L21 and this https://github.com/robtimus/go-obfuscate/blob/master/httpHeaders.go#L14. 
Therefore, I hope that this correction will be appropriate. 

Thank you.